### PR TITLE
[refactor] 카테고리 데이터 인터페이스 구조 등 변경

### DIFF
--- a/src/class/Category.ts
+++ b/src/class/Category.ts
@@ -1,3 +1,7 @@
+/**
+ * 카테고리성 데이터의 상위 클래스.
+ * key: 해당 카테고리의 고유 식별자. 같은 레벨의 카테고리 안에서 유일해야 함.
+ */
 export default interface Category {
   key: string;
 }

--- a/src/class/LargeCategory.ts
+++ b/src/class/LargeCategory.ts
@@ -1,9 +1,0 @@
-import Category from "./Category";
-
-/**
- * 대분류.
- */
-export default interface LargeCategory extends Category {
-  theme: string;
-  name: string;
-}

--- a/src/class/MediumCategory.ts
+++ b/src/class/MediumCategory.ts
@@ -1,9 +1,0 @@
-import Category from "./Category";
-
-/**
- * 중분류.
- */
-export default interface MediumCategory extends Category{
-  largeCategory: string;
-  name: string;
-}

--- a/src/class/SmallCategory.ts
+++ b/src/class/SmallCategory.ts
@@ -1,9 +1,0 @@
-import Category from "./Category";
-
-/**
- * 소분류.
- */
-export default interface SmallCategory extends Category {
-  mediumCategory: string;
-  name: string;
-}

--- a/src/class/Theme.ts
+++ b/src/class/Theme.ts
@@ -1,7 +1,0 @@
-import Category from "./Category";
-
-/**
- * 주제.
- */
-export default interface Theme extends Category{
-}

--- a/src/hook/useCascadingCategory.ts
+++ b/src/hook/useCascadingCategory.ts
@@ -3,25 +3,27 @@ import Category from "../class/Category"
 /**
  * 해당 카테고리의 레벨. string 형태로 저장
  */
-export enum CategoryLevel {
-  THEME = 'theme',
-  LARGE_CATEGORY = 'large_category',
-  MEDIUM_CATEGORY = 'medium_category',
-  SMALL_CATEGORY = 'small_category'
-}
+export const CategoryLevel = {
+  THEME: 'theme',
+  LARGE_CATEGORY: 'large_category',
+  MEDIUM_CATEGORY: 'medium_category',
+  SMALL_CATEGORY: 'small_category'
+} as const
+
+
 
 /**
  * @returns [  
- * `currentLevel` 현재 카테고리의 레벨,  
- * `currentKey` 현재 카테고리의 키,  
+ * `currentLevel` 현재 선택된 카테고리의 레벨,  
+ * `currentCategory` 현재 선택된 카테고리 객체 (없으면 null 반환),  
  * `getChildren` 현재 카테고리 하위의 카테고리를 반환하는 함수,  
  * `chooseChild` 하위 카테고리의 키를 인자로 받아 현재 카테고리로 선택하는 함수, 
  * `chooseRandom` 하위 카테고리 중 하나를 랜덤으로 선택하는 함수  
  * ] 
  */
 export default function useCascadingCategory(): [
-  currentLevel: CategoryLevel,
-  currentKey: Category| null,
+  currentLevel: typeof CategoryLevel[keyof typeof CategoryLevel],
+  currentCategory: Category | null,
   getChildren: () => Category[],
   chooseChild: (childKey: string) => void,
   chooseRandom: () => void
@@ -29,5 +31,5 @@ export default function useCascadingCategory(): [
   const getChildren: () => Category[] = () => []
   const chooseChild: (childKey: string) => void = () => {}
   const chooseRandom: () => void = () => {}
-  return [CategoryLevel.THEME, null, getChildren, chooseChild, chooseRandom]
+  return ["theme", null, getChildren, chooseChild, chooseRandom]
 }

--- a/src/interface/Category.ts
+++ b/src/interface/Category.ts
@@ -4,4 +4,5 @@
  */
 export default interface Category {
   key: string;
+  name: string;
 }

--- a/src/interface/ChildCategory.ts
+++ b/src/interface/ChildCategory.ts
@@ -1,0 +1,8 @@
+import Category from "./Category";
+
+/**
+ * Category 인터페이스를 상속하며, parentKey 값을 갖는 자식 카테고리.
+ */
+export default interface ChildCategory extends Category {
+  parentKey: string
+}

--- a/src/interface/LargeCategory.ts
+++ b/src/interface/LargeCategory.ts
@@ -1,0 +1,7 @@
+import ChildCategory from "./ChildCategory";
+
+/**
+ * 대분류.
+ */
+export default interface LargeCategory extends ChildCategory {
+}

--- a/src/interface/MediumCategory.ts
+++ b/src/interface/MediumCategory.ts
@@ -1,0 +1,7 @@
+import ChildCategory from "./ChildCategory";
+
+/**
+ * 중분류.
+ */
+export default interface MediumCategory extends ChildCategory{
+}

--- a/src/interface/SmallCategory.ts
+++ b/src/interface/SmallCategory.ts
@@ -1,0 +1,7 @@
+import ChildCategory from "./ChildCategory";
+
+/**
+ * 소분류.
+ */
+export default interface SmallCategory extends ChildCategory{
+}

--- a/src/interface/ThemeCategory.ts
+++ b/src/interface/ThemeCategory.ts
@@ -1,0 +1,7 @@
+import Category from "./Category";
+
+/**
+ * 주제.
+ */
+export default interface ThemeCategory extends Category{
+}


### PR DESCRIPTION
1. 데이터 인터페이스(타입)와 리포지터리성 클래스를 분리해 관리하기 위해 폴더명 변경.
리포지터리성 데이터를 src/class 에 저장, 단순 데이터 인터페이스는 src/interface에 저장.
2. 부모-자식 관계가 있는 데이터를 ChildCategory 데이터 인터페이스 상속받도록 변경.
부모 카테고리를 parentKey로 저장하게 함.
3. categoryGetters 내 타입 실수와 오탈자 수정 등.